### PR TITLE
Add catalog to SFCC search products API query

### DIFF
--- a/actions/full/external/sync/index.js
+++ b/actions/full/external/sync/index.js
@@ -23,17 +23,40 @@ const { defineMain } = require('../../../telemetry');
 const {
   configureAcoClient,
   configureSalesforceApiOptions,
+  createSalesforceAdminHttpClient,
+  getSalesforceSiteCatalogId,
   syncAllMetadata,
   syncAllPriceBooks,
   syncAllProducts,
 } = require('../../../../api');
 
+const getSiteCatalogId = async (salesforceClient, salesforceOrgId, siteId, logger) => {
+  logger.debug(`Retrieving catalog id for site ${siteId} from Salesforce`);
+  const res = await getSalesforceSiteCatalogId(salesforceClient, salesforceOrgId, siteId);
+  if (!res.ok) {
+    if (res.status === 404) {
+      logger.error(`No catalog id is assigned to SFCC siteId: ${siteId}`);
+    } else {
+      logger.error(`Failed to retrieve catalog id from Salesforce: ${res.status} ${res.statusText}`);
+    }
+    throw new StarterKitActionError('Failed to retrieve catalog id from Salesforce', res.status, res.statusText);
+  }
+  /** @type {SalesforceSiteCatalogResponse} */
+  const data = await res.json();
+  const catalogId = data.id;
+  logger.debug(`Using catalog id ${catalogId} for site ${siteId}`);
+  return catalogId;
+};
+
 const fullSyncSite = async (params, logger) => {
   /** @type {SalesforceApiOptions} */
   const salesforceApiOptions = configureSalesforceApiOptions(params);
+  const salesforceClient = await createSalesforceAdminHttpClient(salesforceApiOptions);
   /** @type {AcoClientOptions} */
   const acoClientOptions = configureAcoClient(params);
   const localesToSync = params.SFCC_LOCALES_TO_SYNC.split(',');
+
+  const catalogId = await getSiteCatalogId(salesforceClient, params.SFCC_ORGANIZATION_ID, params.SFCC_SITE_ID, logger);
 
   await syncAllMetadata(acoClientOptions, localesToSync, logger);
 
@@ -51,6 +74,7 @@ const fullSyncSite = async (params, logger) => {
       acoClientOptions,
       params.SFCC_ORGANIZATION_ID,
       params.SFCC_SITE_ID,
+      catalogId,
       locale,
       logger,
     );

--- a/api/products.js
+++ b/api/products.js
@@ -17,8 +17,8 @@ const { createAcoClient } = require('./aco');
 const { syncPricesFromProducts } = require('./prices');
 const {
   createSalesforceAdminHttpClient,
-  searchSalesforceProducts,
   getSalesforceProductByIds,
+  searchSalesforceProducts,
 } = require('./salesforce');
 const { AIO_STATE_MAX_TTL, AIO_STATE_KEY_LAST_SYNC } = require('../actions/constants');
 const { StarterKitActionError } = require('../actions/responses');
@@ -33,11 +33,20 @@ const BATCH_SIZE = 100;
  * @param {AcoClientOptions} acoClientOptions - Configuration options for the ACO client.
  * @param {string} salesforceOrgId - The Salesforce organization ID.
  * @param {string} siteId - The Salesforce site ID.
+ * @param {string} catalogId - The catalog ID assigned to the Salesforce site.
  * @param {string} locale - The locale to sync.
  * @param {ReturnType<typeof Core.Logger>} logger - The logger instance
  * @throws {StarterKitActionError} If there's an error retrieving or syncing the product
  */
-const syncAllProducts = async (salesforceApiOptions, acoClientOptions, salesforceOrgId, siteId, locale, logger) => {
+const syncAllProducts = async (
+  salesforceApiOptions,
+  acoClientOptions,
+  salesforceOrgId,
+  siteId,
+  catalogId,
+  locale,
+  logger,
+) => {
   logger.info(`Syncing all products from Salesforce to ACO for siteId: ${siteId} and locale: ${locale}`);
 
   logger.debug('Initializing AIO state lib');
@@ -54,9 +63,14 @@ const syncAllProducts = async (salesforceApiOptions, acoClientOptions, salesforc
   let totalAccepted = 0;
 
   do {
-    const res = await searchSalesforceProducts(salesforceClient, salesforceOrgId, siteId, BATCH_SIZE, offset, '*', [
-      'none',
-    ]);
+    const res = await searchSalesforceProducts(
+      salesforceClient,
+      salesforceOrgId,
+      siteId,
+      catalogId,
+      BATCH_SIZE,
+      offset,
+    );
     if (!res.ok) {
       logger.error(`[${locale}] Failed to retrieve product ids from Salesforce: ${res.status} ${res.statusText}`);
       throw new StarterKitActionError('Failed to retrieve product ids from Salesforce', res.status, res.statusText);

--- a/api/salesforce.js
+++ b/api/salesforce.js
@@ -107,6 +107,22 @@ const checkSalesforceConnectivity = async (client, organizationId, siteId) => {
 };
 
 /**
+ * Get the catalog ID assigned to the site from Salesforce via our custom endpoint.
+ *
+ * @param {import('ky').KyInstance} client - The Salesforce HTTP client.
+ * @param {string} organizationId - The Salesforce organization ID.
+ * @param {string} siteId - The Salesforce site ID.
+ * @returns {Promise<import('ky').KyResponse>} The response from the Salesforce API.
+ */
+const getSalesforceSiteCatalogId = async (client, organizationId, siteId) => {
+  return await client.get(`custom/aco/v1/organizations/${organizationId}/catalog`, {
+    searchParams: {
+      siteId,
+    },
+  });
+};
+
+/**
  * Get price books from Salesforce via our custom endpoint.
  *
  * @param {import('ky').KyInstance} client - The Salesforce HTTP client.
@@ -193,24 +209,24 @@ const getSalesforceTrackedChanges = async (client, organizationId, siteId, limit
  * @param {import('ky').KyInstance} client - The Salesforce HTTP client.
  * @param {string} organizationId - The Salesforce organization ID.
  * @param {string} siteId - The Salesforce site ID.
+ * @param {string} catalogId - The catalog ID to search for.
  * @param {number} limit - The response page size. Max 200.
  * @param {number} offset - The response page offset for pagination.
- * @param {string} searchPhrase - The search phrase to look for in product names.
- * @param {string[]} expand - The expand parameter to pass to the Salesforce API.
  * @returns {Promise<import('ky').KyResponse>} The response from the Salesforce API.
  */
-const searchSalesforceProducts = async (client, organizationId, siteId, limit, offset, searchPhrase, expand) => {
+const searchSalesforceProducts = async (client, organizationId, siteId, catalogId, limit, offset) => {
   return await client.post(`product/products/v1/organizations/${organizationId}/product-search`, {
     searchParams: { siteId },
     body: JSON.stringify({
       limit,
       query: {
-        textQuery: {
-          fields: ['name'],
-          searchPhrase,
+        termQuery: {
+          fields: ['catalogId'],
+          operator: 'is',
+          values: [catalogId],
         },
       },
-      expand,
+      expand: ['none'],
       offset,
     }),
   });
@@ -223,6 +239,7 @@ module.exports = {
   getSalesforcePriceBooks,
   getSalesforcePriceBookById,
   getSalesforceProductByIds,
+  getSalesforceSiteCatalogId,
   getSalesforceTrackedChanges,
   searchSalesforceProducts,
 };

--- a/types/salesforce.d.ts
+++ b/types/salesforce.d.ts
@@ -16,6 +16,14 @@ declare interface SalesforceOAuthTokenResponse {
   expires_in: number;
 }
 
+declare interface SalesforceSiteCatalogResponse {
+  id: string;
+  displayName: string;
+  description: string;
+  creationDate: string;
+  lastModified: string;
+}
+
 declare interface SalesforceProductsResponse {
   count: number;
   data: SalesforceProduct[];


### PR DESCRIPTION
Use the `catalogId` field in the `searchSalesforceProducts` API in order to correctly filter data returned from Salesforce SCAPI. 

This is required because although you can only assign 1 catalog to an SFCC site and the `siteId` param is required on SCAPI admin APIs, I was still able to query products from different catalogs 😕. 

This PR allows to work around that issue and uses the new `/catalog` custom API to retrieve the currently assigned catalog for a given SFCC site.